### PR TITLE
fix bug, when value not showed with readonly=true

### DIFF
--- a/src/TextareaMarkdownEditor.tsx
+++ b/src/TextareaMarkdownEditor.tsx
@@ -141,7 +141,7 @@ class TextareaMarkdownEditor extends React.Component<ITextareaMarkdownEditor, IT
               className={classNames('tme-viewer', this.props.viewerClassName)}
               style={this.props.viewerStyle}
               dangerouslySetInnerHTML={{
-                __html: this.textareaRef.current ? this.props.doParse(this.textareaRef.current.value) : '',
+                __html: this.state.value ? this.props.doParse(this.state.value) : '',
               }}
             />
           )}


### PR DESCRIPTION
when we set readOnly true - textarea is not rendered so this.textareaRef.current with readOnly:true will be always === false.